### PR TITLE
Display spaces only where available is true

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -3,6 +3,7 @@ class SpacesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
+    @user = current_user
     if params[:query].present?
       coordinates = Geocoder.search(params[:query]).first.data["center"]
       @markers = [
@@ -102,9 +103,11 @@ class SpacesController < ApplicationController
   end
 
   def set_space_markers
+    @user = current_user
     @spaces = policy_scope(Space)
     @spaces_location = Space.where.not(latitude: nil, longitude: nil)
-    @space_markers = @spaces_location.map do |space|
+    @spaces_available = @spaces_location.where(available: true)
+    @space_markers = @spaces_available.map do |space|
       {
         lat: space.latitude,
         lng: space.longitude,

--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -2,9 +2,7 @@
   id="space_map"
   style="width: 100%; height: calc(100vh - 66px);"
   data-markers="<%= @markers.to_json %>"
-<% if current_user %>
   data-ssmarkers="<%= @space_markers.to_json%>"
-  <% end %>
   data-kobanmarkers="<%= @koban_markers.to_json %>"
   data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>">
   <%= simple_form_for @incident do |f|%>


### PR DESCRIPTION
Created a new array of spaces where availability is equal to true and used those as a basis for displaying markers instead of all markers. Users not logged in are still able to see safe spaces though.